### PR TITLE
ruby 3.2.2 exists

### DIFF
--- a/measure/systems_analysis_report_generator/measure.rb
+++ b/measure/systems_analysis_report_generator/measure.rb
@@ -86,7 +86,7 @@ class SystemsAnalysisReportGenerator < OpenStudio::Measure::ReportingMeasure
     file_path = runner.workflow.findFile('reportConfig.json')
     unless file_path.empty?
       file_path = file_path.get if file_path.is_initialized
-      return file_path.to_s if File.exists? file_path.to_s
+      return file_path.to_s if File.exist? file_path.to_s
     else
       runner.registerWarning("Could not find reportConfig.json in root. Using default configuration instead")
     end


### PR DESCRIPTION
Fix https://jira.autodesk.com/browse/REVIT-223936?focusedId=12498844&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-12498844.

>C:/PROGRA~1/NREL/OPENST~4/measures/systems_analysis_report_generator/measure.rb:89:in `get_config_path'
C:/PROGRA~1/NREL/OPENST~4/measures/systems_analysis_report_generator/measure.rb:57:in `run'
[13:30:34.988933 ERROR] [openstudio.workflow.OSWorkflow] Found error in state 'ReportingMeasures' with message: 'Runner error: Measure 'C:/PROGRA~1/NREL/OPENST~4/measures/systems_analysis_report_generator/measure.rb' reported an error with [SWIG director method error. NoMethodError: undefined method `exists?' for File:Class